### PR TITLE
Add tournament OpenAPI contract

### DIFF
--- a/contracts/openapi/tournament-service.yaml
+++ b/contracts/openapi/tournament-service.yaml
@@ -1,0 +1,242 @@
+openapi: 3.1.0
+info:
+  title: Edusupreme Tournament Service API
+  version: 0.1.0
+  description: API-first contract for the first tournament vertical slice.
+servers:
+  - url: http://localhost:8081
+    description: Local tournament service
+tags:
+  - name: Tournaments
+    description: Tournament creation and listing.
+paths:
+  /tournaments:
+    post:
+      tags:
+        - Tournaments
+      summary: Create a tournament
+      operationId: createTournament
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateTournamentRequest"
+            examples:
+              localOpen:
+                summary: Local open tournament
+                value:
+                  name: Madrid Spring Open
+                  startsAt: "2026-06-20T09:00:00+02:00"
+                  venueName: Centro Deportivo Municipal
+                  city: Madrid
+      responses:
+        "201":
+          description: Tournament created.
+          headers:
+            Location:
+              description: Absolute or relative URL for the created tournament resource.
+              schema:
+                type: string
+                format: uri-reference
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TournamentResponse"
+        "400":
+          $ref: "#/components/responses/ValidationProblem"
+    get:
+      tags:
+        - Tournaments
+      summary: List tournaments
+      operationId: listTournaments
+      parameters:
+        - name: page
+          in: query
+          description: Zero-based page index.
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+        - name: size
+          in: query
+          description: Number of tournaments to return per page.
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        "200":
+          description: Tournaments returned in newest-first order.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListTournamentsResponse"
+components:
+  responses:
+    ValidationProblem:
+      description: Request validation failed.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+  schemas:
+    CreateTournamentRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - startsAt
+      properties:
+        name:
+          type: string
+          description: Human-readable tournament name. Must be unique enough for organizers to distinguish upcoming events.
+          minLength: 3
+          maxLength: 120
+          examples:
+            - Madrid Spring Open
+        startsAt:
+          type: string
+          format: date-time
+          description: Scheduled start date and time, including timezone offset. Must be in the future when the tournament is created.
+          examples:
+            - "2026-06-20T09:00:00+02:00"
+        venueName:
+          type: string
+          description: Optional venue or club name where the tournament is played.
+          minLength: 2
+          maxLength: 160
+          examples:
+            - Centro Deportivo Municipal
+        city:
+          type: string
+          description: Optional city for search and display.
+          minLength: 2
+          maxLength: 100
+          examples:
+            - Madrid
+    TournamentResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - startsAt
+        - status
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Stable tournament identifier.
+          examples:
+            - 018f3904-09fb-7d19-baf4-3d10a2f0bb99
+        name:
+          type: string
+          minLength: 3
+          maxLength: 120
+          examples:
+            - Madrid Spring Open
+        startsAt:
+          type: string
+          format: date-time
+          examples:
+            - "2026-06-20T09:00:00+02:00"
+        venueName:
+          type: string
+          minLength: 2
+          maxLength: 160
+          examples:
+            - Centro Deportivo Municipal
+        city:
+          type: string
+          minLength: 2
+          maxLength: 100
+          examples:
+            - Madrid
+        status:
+          $ref: "#/components/schemas/TournamentStatus"
+        createdAt:
+          type: string
+          format: date-time
+          description: Server timestamp for when the tournament resource was created.
+          examples:
+            - "2026-05-07T10:15:30Z"
+    ListTournamentsResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - items
+        - page
+        - size
+        - totalItems
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/TournamentResponse"
+        page:
+          type: integer
+          minimum: 0
+          description: Zero-based page index returned.
+          examples:
+            - 0
+        size:
+          type: integer
+          minimum: 1
+          maximum: 100
+          description: Requested page size.
+          examples:
+            - 20
+        totalItems:
+          type: integer
+          minimum: 0
+          description: Total tournaments matching the list query.
+          examples:
+            - 1
+    TournamentStatus:
+      type: string
+      description: Current lifecycle state for a tournament.
+      enum:
+        - DRAFT
+        - SCHEDULED
+        - IN_PROGRESS
+        - COMPLETED
+        - CANCELLED
+      examples:
+        - SCHEDULED
+    ProblemDetails:
+      type: object
+      additionalProperties: true
+      required:
+        - type
+        - title
+        - status
+      properties:
+        type:
+          type: string
+          format: uri-reference
+          examples:
+            - about:blank
+        title:
+          type: string
+          examples:
+            - Bad Request
+        status:
+          type: integer
+          minimum: 400
+          maximum: 599
+          examples:
+            - 400
+        detail:
+          type: string
+          examples:
+            - name must be between 3 and 120 characters
+        instance:
+          type: string
+          format: uri-reference
+          examples:
+            - /tournaments


### PR DESCRIPTION
## Summary
- Add the tournament service OpenAPI 3.1 contract under contracts/openapi
- Define create tournament request/response shapes
- Define list tournaments response with simple pagination metadata
- Document validation expectations in schema fields where practical

## Verification
- Parsed YAML successfully
- Resolved internal OpenAPI references
- Checked Prettier formatting

Closes #7