### PR TITLE
Implement GET /tournaments

### DIFF
--- a/apps/tournament-service/src/main/java/com/edusupreme/tournament/api/ListTournamentsResponse.java
+++ b/apps/tournament-service/src/main/java/com/edusupreme/tournament/api/ListTournamentsResponse.java
@@ -1,0 +1,21 @@
+package com.edusupreme.tournament.api;
+
+import com.edusupreme.tournament.application.port.in.ListTournamentsResult;
+import java.util.List;
+
+public record ListTournamentsResponse(
+        List<TournamentResponse> items,
+        int page,
+        int size,
+        long totalItems) {
+
+    static ListTournamentsResponse from(ListTournamentsResult result) {
+        return new ListTournamentsResponse(
+                result.items().stream()
+                        .map(TournamentResponse::from)
+                        .toList(),
+                result.page(),
+                result.size(),
+                result.totalItems());
+    }
+}

--- a/apps/tournament-service/src/main/java/com/edusupreme/tournament/api/TournamentController.java
+++ b/apps/tournament-service/src/main/java/com/edusupreme/tournament/api/TournamentController.java
@@ -2,24 +2,42 @@ package com.edusupreme.tournament.api;
 
 import com.edusupreme.tournament.application.port.in.CreateTournamentCommand;
 import com.edusupreme.tournament.application.port.in.CreateTournamentUseCase;
+import com.edusupreme.tournament.application.port.in.ListTournamentsUseCase;
 import com.edusupreme.tournament.domain.model.Tournament;
 import com.edusupreme.tournament.domain.model.TournamentStatus;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.Valid;
 import java.net.URI;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/tournaments")
+@Validated
 public class TournamentController {
 
     private final CreateTournamentUseCase createTournamentUseCase;
+    private final ListTournamentsUseCase listTournamentsUseCase;
 
-    public TournamentController(CreateTournamentUseCase createTournamentUseCase) {
+    public TournamentController(
+            CreateTournamentUseCase createTournamentUseCase,
+            ListTournamentsUseCase listTournamentsUseCase) {
         this.createTournamentUseCase = createTournamentUseCase;
+        this.listTournamentsUseCase = listTournamentsUseCase;
+    }
+
+    @GetMapping
+    ResponseEntity<ListTournamentsResponse> listTournaments(
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size) {
+        return ResponseEntity.ok(ListTournamentsResponse.from(listTournamentsUseCase.listTournaments(page, size)));
     }
 
     @PostMapping

--- a/apps/tournament-service/src/main/java/com/edusupreme/tournament/application/port/in/ListTournamentsResult.java
+++ b/apps/tournament-service/src/main/java/com/edusupreme/tournament/application/port/in/ListTournamentsResult.java
@@ -1,0 +1,10 @@
+package com.edusupreme.tournament.application.port.in;
+
+import com.edusupreme.tournament.domain.model.Tournament;
+import java.util.List;
+
+public record ListTournamentsResult(
+        List<Tournament> items,
+        int page,
+        int size,
+        long totalItems) {}

--- a/apps/tournament-service/src/main/java/com/edusupreme/tournament/application/port/in/ListTournamentsUseCase.java
+++ b/apps/tournament-service/src/main/java/com/edusupreme/tournament/application/port/in/ListTournamentsUseCase.java
@@ -1,0 +1,6 @@
+package com.edusupreme.tournament.application.port.in;
+
+public interface ListTournamentsUseCase {
+
+    ListTournamentsResult listTournaments(int page, int size);
+}

--- a/apps/tournament-service/src/main/java/com/edusupreme/tournament/application/port/out/TournamentRepository.java
+++ b/apps/tournament-service/src/main/java/com/edusupreme/tournament/application/port/out/TournamentRepository.java
@@ -1,8 +1,13 @@
 package com.edusupreme.tournament.application.port.out;
 
 import com.edusupreme.tournament.domain.model.Tournament;
+import java.util.List;
 
 public interface TournamentRepository {
+
+    List<Tournament> findAllNewestFirst(int page, int size);
+
+    long count();
 
     Tournament save(Tournament tournament);
 }

--- a/apps/tournament-service/src/main/java/com/edusupreme/tournament/application/usecase/ListTournamentsHandler.java
+++ b/apps/tournament-service/src/main/java/com/edusupreme/tournament/application/usecase/ListTournamentsHandler.java
@@ -1,0 +1,28 @@
+package com.edusupreme.tournament.application.usecase;
+
+import com.edusupreme.tournament.application.port.in.ListTournamentsResult;
+import com.edusupreme.tournament.application.port.in.ListTournamentsUseCase;
+import com.edusupreme.tournament.application.port.out.TournamentRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ListTournamentsHandler implements ListTournamentsUseCase {
+
+    private final TournamentRepository tournamentRepository;
+
+    public ListTournamentsHandler(TournamentRepository tournamentRepository) {
+        this.tournamentRepository = tournamentRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ListTournamentsResult listTournaments(int page, int size) {
+        return new ListTournamentsResult(
+                List.copyOf(tournamentRepository.findAllNewestFirst(page, size)),
+                page,
+                size,
+                tournamentRepository.count());
+    }
+}

--- a/apps/tournament-service/src/main/java/com/edusupreme/tournament/persistence/JpaTournamentRepository.java
+++ b/apps/tournament-service/src/main/java/com/edusupreme/tournament/persistence/JpaTournamentRepository.java
@@ -2,6 +2,9 @@ package com.edusupreme.tournament.persistence;
 
 import com.edusupreme.tournament.application.port.out.TournamentRepository;
 import com.edusupreme.tournament.domain.model.Tournament;
+import java.util.List;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,6 +14,23 @@ class JpaTournamentRepository implements TournamentRepository {
 
     JpaTournamentRepository(SpringDataTournamentJpaRepository springDataRepository) {
         this.springDataRepository = springDataRepository;
+    }
+
+    @Override
+    public List<Tournament> findAllNewestFirst(int page, int size) {
+        PageRequest pageRequest = PageRequest.of(
+                page,
+                size,
+                Sort.by(Sort.Direction.DESC, "createdAt").and(Sort.by(Sort.Direction.DESC, "id")));
+
+        return springDataRepository.findAll(pageRequest).stream()
+                .map(TournamentJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public long count() {
+        return springDataRepository.count();
     }
 
     @Override

--- a/apps/tournament-service/src/test/java/com/edusupreme/tournament/TournamentApiIntegrationTests.java
+++ b/apps/tournament-service/src/test/java/com/edusupreme/tournament/TournamentApiIntegrationTests.java
@@ -1,11 +1,18 @@
 package com.edusupreme.tournament;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -39,6 +46,11 @@ class TournamentApiIntegrationTests {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    @BeforeEach
+    void deleteTournaments() {
+        jdbcTemplate.update("DELETE FROM tournaments");
+    }
+
     @Test
     void createsTournamentAndPersistsIt() throws Exception {
         String requestBody = """
@@ -71,6 +83,49 @@ class TournamentApiIntegrationTests {
     }
 
     @Test
+    void listsTournamentsNewestFirst() throws Exception {
+        insertTournament(
+                UUID.fromString("018f3904-09fb-7d19-baf4-3d10a2f0bb99"),
+                "Madrid Spring Open",
+                LocalDate.parse("2026-06-20"),
+                LocalDate.parse("2026-06-21"),
+                "SCHEDULED",
+                Instant.parse("2026-05-07T10:15:30Z"));
+        insertTournament(
+                UUID.fromString("018f3904-09fb-7d19-baf4-3d10a2f0bb9a"),
+                "Barcelona Summer Cup",
+                LocalDate.parse("2026-07-10"),
+                LocalDate.parse("2026-07-12"),
+                "DRAFT",
+                Instant.parse("2026-05-08T10:15:30Z"));
+
+        mockMvc.perform(get("/tournaments"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items", hasSize(2)))
+                .andExpect(jsonPath("$.items[0].id").value("018f3904-09fb-7d19-baf4-3d10a2f0bb9a"))
+                .andExpect(jsonPath("$.items[0].name").value("Barcelona Summer Cup"))
+                .andExpect(jsonPath("$.items[0].startDate").value("2026-07-10"))
+                .andExpect(jsonPath("$.items[0].endDate").value("2026-07-12"))
+                .andExpect(jsonPath("$.items[0].status").value("DRAFT"))
+                .andExpect(jsonPath("$.items[0].createdAt").value("2026-05-08T10:15:30Z"))
+                .andExpect(jsonPath("$.items[1].id").value("018f3904-09fb-7d19-baf4-3d10a2f0bb99"))
+                .andExpect(jsonPath("$.items[1].name").value("Madrid Spring Open"))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.size").value(20))
+                .andExpect(jsonPath("$.totalItems").value(2));
+    }
+
+    @Test
+    void listsEmptyTournaments() throws Exception {
+        mockMvc.perform(get("/tournaments"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items", hasSize(0)))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.size").value(20))
+                .andExpect(jsonPath("$.totalItems").value(0));
+    }
+
+    @Test
     void rejectsInvalidTournamentName() throws Exception {
         String requestBody = """
                 {
@@ -100,5 +155,25 @@ class TournamentApiIntegrationTests {
                         .contentType("application/json")
                         .content(requestBody))
                 .andExpect(status().isBadRequest());
+    }
+
+    private void insertTournament(
+            UUID id,
+            String name,
+            LocalDate startDate,
+            LocalDate endDate,
+            String status,
+            Instant createdAt) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO tournaments (id, name, start_date, end_date, status, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                id,
+                name,
+                startDate,
+                endDate,
+                status,
+                Timestamp.from(createdAt));
     }
 }


### PR DESCRIPTION
## Summary
- Add GET /tournaments with OpenAPI-compatible list response fields
- Query tournaments newest-first with a stable ID tiebreaker
- Cover populated and empty listing responses with integration tests

## Verification
- ./gradlew test
- ./gradlew build

Closes #9