### PR TITLE
M1: Add Flyway schema verification for tournaments

### DIFF
--- a/apps/tournament-service/src/test/java/com/edusupreme/tournament/TournamentApiIntegrationTests.java
+++ b/apps/tournament-service/src/test/java/com/edusupreme/tournament/TournamentApiIntegrationTests.java
@@ -52,6 +52,21 @@ class TournamentApiIntegrationTests {
     }
 
     @Test
+    void appliesFlywayMigrationOnStartup() {
+        Integer migrationCount = jdbcTemplate.queryForObject(
+                """
+                SELECT count(*)
+                FROM flyway_schema_history
+                WHERE version = '1'
+                    AND script = 'V1__create_tournaments.sql'
+                    AND success = true
+                """,
+                Integer.class);
+
+        assertThat(migrationCount).isEqualTo(1);
+    }
+
+    @Test
     void createsTournamentAndPersistsIt() throws Exception {
         String requestBody = """
                 {


### PR DESCRIPTION
## Summary
- Add integration coverage that verifies Flyway applied the initial tournament migration on service startup.
- Keep schema compatibility covered by JPA validation and existing API behavior tests instead of duplicating column definitions in tests.

## Tests
- ./gradlew test --rerun-tasks

Closes #10